### PR TITLE
Fixed environment segfaults

### DIFF
--- a/common/src/environment_wrapper.cpp
+++ b/common/src/environment_wrapper.cpp
@@ -358,7 +358,11 @@ DefaultEnvironmentWrapper::DefaultEnvironmentWrapper(ComponentInfo component_inf
   qGuiApp->installEventFilter(this);
 }
 
-DefaultEnvironmentWrapper::~DefaultEnvironmentWrapper() = default;
+DefaultEnvironmentWrapper::~DefaultEnvironmentWrapper()
+{
+  if (initialized_ && env_)
+    env_->removeEventCallback(std::hash<EnvironmentWrapper*>()(this));
+}
 
 std::shared_ptr<const tesseract_environment::Environment> DefaultEnvironmentWrapper::getEnvironment() const
 {
@@ -389,7 +393,13 @@ MonitorEnvironmentWrapper::MonitorEnvironmentWrapper(
   // Install event filter for interactive view controller
   qGuiApp->installEventFilter(this);
 }
-MonitorEnvironmentWrapper::~MonitorEnvironmentWrapper() = default;
+
+MonitorEnvironmentWrapper::~MonitorEnvironmentWrapper()
+{
+  if (initialized_ && env_monitor_) {
+    environment().removeEventCallback(std::hash<EnvironmentWrapper *>()(this));
+  }
+}
 
 std::shared_ptr<const tesseract_environment::Environment> MonitorEnvironmentWrapper::getEnvironment() const
 {

--- a/common/src/environment_wrapper.cpp
+++ b/common/src/environment_wrapper.cpp
@@ -396,9 +396,8 @@ MonitorEnvironmentWrapper::MonitorEnvironmentWrapper(
 
 MonitorEnvironmentWrapper::~MonitorEnvironmentWrapper()
 {
-  if (initialized_ && env_monitor_) {
-    environment().removeEventCallback(std::hash<EnvironmentWrapper *>()(this));
-  }
+  if (initialized_ && env_monitor_)
+    environment().removeEventCallback(std::hash<EnvironmentWrapper*>()(this));
 }
 
 std::shared_ptr<const tesseract_environment::Environment> MonitorEnvironmentWrapper::getEnvironment() const

--- a/joint_trajectory/src/models/joint_trajectory_model.cpp
+++ b/joint_trajectory/src/models/joint_trajectory_model.cpp
@@ -81,7 +81,7 @@ void JointTrajectoryModel::addJointTrajectorySet(tesseract_common::JointTrajecto
     if (env_wrapper != nullptr)
     {
       auto env = env_wrapper->getEnvironment();
-      if (env != nullptr || env->isInitialized())
+      if (env != nullptr && env->isInitialized())
         trajectory_set.applyEnvironment(env->clone());
     }
     else
@@ -90,7 +90,7 @@ void JointTrajectoryModel::addJointTrajectorySet(tesseract_common::JointTrajecto
       if (env_wrapper != nullptr)
       {
         auto env = env_wrapper->getEnvironment();
-        if (env != nullptr || env->isInitialized())
+        if (env != nullptr && env->isInitialized())
           trajectory_set.applyEnvironment(env->clone());
       }
     }


### PR DESCRIPTION
This fixes segfaults that happen occasionally in certain use-cases (mostly creating/deleting components while some processes are running)

reproducible e.g. with
 - Ubuntu 22.04.02 LTS
 - `ros-humble-rclcpp 16.0.3-1jammy.20230302.174123`
 - `ros-humble-ompl 1.6.0-1jammy.20230117.223758`
 - `tesseract_ros2` from [marrts/0_15-parity](https://github.com/marrts/tesseract_ros2/tree/0_15-parity) branch

when launching tesseract_ros_examples (and e.g. changing TesseractWorkbench Display Mode to URDF and back to Monitor multiple times)