### PR TITLE
Fix build issue with configure_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,4 +72,4 @@ configure_package(
             DEPENDENCIES
             ${DEPS}
             CFG_EXTRAS
-            tesseract_qt-extras.cmake)
+            cmake/tesseract_qt-extras.cmake)


### PR DESCRIPTION
Not sure if this is correct, but for building tesseract_ros2 on Ubuntu 22.04 this fixes a build problem.