### PR TITLE
Adapts TaskComposerProblemStandardItem to the new input

### DIFF
--- a/common/src/entity_container.cpp
+++ b/common/src/entity_container.cpp
@@ -22,6 +22,7 @@
  */
 #include <tesseract_qt/common/entity_container.h>
 #include <tesseract_qt/common/entity_manager.h>
+#include <stdexcept>
 
 namespace tesseract_gui
 {

--- a/planning/src/task_composer_problem_standard_item.cpp
+++ b/planning/src/task_composer_problem_standard_item.cpp
@@ -85,18 +85,18 @@ void TaskComposerProblemStandardItem::ctor(const tesseract_planning::TaskCompose
 
   appendRow(new ManipulatorInfoStandardItem("global_manip_info", planning_problem->manip_info));
 
-  if (planning_problem->input_instruction.isNull())
+  if (planning_problem->input.isNull())
   {
-    appendRow(new NullInstructionStandardItem("input_instruction"));
+    appendRow(new NullInstructionStandardItem("input"));
   }
-  else if (planning_problem->input_instruction.isCompositeInstruction())
+  else if (planning_problem->input.getType() == std::type_index(typeid(tesseract_planning::CompositeInstruction)))
   {
     appendRow(new CompositeInstructionStandardItem(
-        "input_instruction", planning_problem->input_instruction.as<tesseract_planning::CompositeInstruction>()));
+        "input", planning_problem->input.as<tesseract_planning::CompositeInstruction>()));
   }
-  else
+  else if (planning_problem->input.getType() == std::type_index(typeid(tesseract_planning::InstructionPoly)))
   {
-    appendRow(new InstructionStandardItem("input_instruction", planning_problem->input_instruction));
+    appendRow(new InstructionStandardItem("input", planning_problem->input.as<tesseract_planning::InstructionPoly>()));
   }
 
   appendRow(


### PR DESCRIPTION
But see my comment [here](https://github.com/tesseract-robotics/tesseract_planning/commit/fe80ad58d423a4073a1b43211309312f69c260e4#r131891345). 

And what to do if the input is neiter a CompositeInstruction nor an InstructionPoly?