### PR TITLE
Added docker files

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+ARG TAG
+FROM ghcr.io/tesseract-robotics/tesseract_planning_deploy:${TAG}
+
+SHELL ["/bin/bash", "-c"]
+
+ENV DEBIAN_FRONTEND noninteractive
+
+USER root
+
+# Bind mount the source directory so as not to unnecessarily copy source code into the docker image
+ARG WORKSPACE_DIR=/opt/tesseract_qt
+RUN --mount=type=bind,target=${WORKSPACE_DIR}/src/tesseract_qt \
+  cd ${WORKSPACE_DIR} \
+  && rosdep install \
+    --from-paths ${WORKSPACE_DIR}/src \
+    -iry
+
+# Build the repository
+# Bind mount the source directory so as not to unnecessarily copy source code into the docker image
+RUN --mount=type=bind,target=${WORKSPACE_DIR}/src/tesseract_qt \
+  source /opt/tesseract_planning/install/setup.bash \
+  && cd ${WORKSPACE_DIR} \ 
+  && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_RENDERING=OFF -DBUILD_STUDIO=OFF \
+  && rm -rf build log

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,28 @@
+# Tesseract Qt Docker
+
+## Create the Docker image
+### Download
+Download a pre-built Docker image for this bridge from the container registry:
+
+```
+docker login ghcr.io
+docker pull ghcr.io/tesseract-robotics/tesseract_qt_deploy:<tag>
+```
+
+### Build
+Build the Docker image using `docker-compose`:
+
+```commandLine
+cd docker
+docker compose build
+```
+
+## Run the docker image
+Run the Docker image using `docker-compose`:
+
+```commandLine
+cd docker
+CURRENT_UID=$(id -u):$(id -g) docker compose up
+```
+
+> Note: by default the docker image runs as a non-root user, so the environment variable `CURRENT_UID` must be supplied as shown above

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  tesseract:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      args:
+        - TAG=focal-0.20
+    environment:
+      DISPLAY: $DISPLAY
+      XAUTHORITY: $XAUTHORITY
+      NVIDIA_DRIVER_CAPABILITIES: all
+    container_name: tesseract_qt
+    image: ghcr.io/tesseract-robotics/tesseract_qt_deploy:focal-0.20
+    stdin_open: true
+    tty: true
+    network_mode: host
+    user: ${CURRENT_UID}  # CURRENT_UID=$(id -u):$(id -g)
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - /etc/hosts:/etc/hosts
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]


### PR DESCRIPTION
This PR adds a `Dockerfile` and Docker compose file for building `tesseract_qt` on top of `tesseract_planning`. This image is intended to be able to function as a base for `tesseract_qt`-based applications.

Note this Docker image builds on top of the `tesseract_planning` deploy image from https://github.com/tesseract-robotics/tesseract_planning/pull/414 so as to minimize build time and layer size.