### PR TITLE
Enable custom naming in trajectory preview panel

### DIFF
--- a/common/include/tesseract_qt/common/joint_trajectory_set.h
+++ b/common/include/tesseract_qt/common/joint_trajectory_set.h
@@ -41,7 +41,16 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_common
 {
-using JointTrajectoryInfo = std::pair<JointState, JointTrajectory>;
+struct JointTrajectoryInfo
+{
+  JointState joint_state;
+  JointTrajectory joint_trajectory;
+  std::string description;
+
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version);  // NOLINT
+};
 
 class JointTrajectorySet
 {

--- a/joint_trajectory/include/tesseract_qt/joint_trajectory/models/joint_trajectory_model.h
+++ b/joint_trajectory/include/tesseract_qt/joint_trajectory/models/joint_trajectory_model.h
@@ -36,7 +36,7 @@ namespace tesseract_common
 class JointTrajectorySet;
 class JointState;
 class JointTrajectory;
-using JointTrajectoryInfo = std::pair<JointState, JointTrajectory>;
+struct JointTrajectoryInfo;
 }  // namespace tesseract_common
 
 namespace boost::uuids

--- a/joint_trajectory/src/models/joint_trajectory_info_item.cpp
+++ b/joint_trajectory/src/models/joint_trajectory_info_item.cpp
@@ -57,10 +57,10 @@ int JointTrajectoryInfoItem::type() const
 
 void JointTrajectoryInfoItem::ctor()
 {
-  for (std::size_t j = 0; j < trajectory_info.second.size(); ++j)
+  for (std::size_t j = 0; j < trajectory_info.joint_trajectory.size(); ++j)
   {
     QStandardItem* trajectory_state =
-        new JointTrajectoryStateItem(QString("state[%1]").arg(j), trajectory_info.second[j]);
+        new JointTrajectoryStateItem(QString("state[%1]").arg(j), trajectory_info.joint_trajectory[j]);
     appendRow(trajectory_state);
   }
 }

--- a/joint_trajectory/src/models/joint_trajectory_set_item.cpp
+++ b/joint_trajectory/src/models/joint_trajectory_set_item.cpp
@@ -30,7 +30,10 @@
 namespace tesseract_gui
 {
 JointTrajectorySetItem::JointTrajectorySetItem(const tesseract_common::JointTrajectorySet& trajectory_set)
-  : QStandardItem(icons::getSetIcon(), "Trajectory Set"), trajectory_set(trajectory_set)
+  : QStandardItem(icons::getSetIcon(),
+                  trajectory_set.getDescription().empty() ? "Trajectory Set" :
+                                                            QString::fromStdString(trajectory_set.getDescription()))
+  , trajectory_set(trajectory_set)
 {
   ctor();
 }
@@ -56,7 +59,9 @@ void JointTrajectorySetItem::ctor()
   for (std::size_t i = 0; i < trajectory_set.size(); ++i)
   {
     tesseract_common::JointTrajectoryInfo& traj_info = trajectory_set[i];
-    QStandardItem* trajectory_item = new JointTrajectoryInfoItem(QString("trajectory[%1]").arg(i), traj_info);
+    QString description = traj_info.description.empty() ? QString("trajectory[%1]").arg(i) :
+                                                          QString::fromStdString(traj_info.description);
+    QStandardItem* trajectory_item = new JointTrajectoryInfoItem(description, traj_info);
     appendRow(trajectory_item);
   }
 }

--- a/joint_trajectory/src/widgets/joint_trajectory_plot_dialog.cpp
+++ b/joint_trajectory/src/widgets/joint_trajectory_plot_dialog.cpp
@@ -34,13 +34,13 @@ JointTrajectoryPlotDialog::JointTrajectoryPlotDialog(tesseract_common::JointTraj
 {
   ui_->setupUi(this);
 
-  ui_->jtpHorizontalSlider->setMinimum(current_trajectory.second.front().time / SLIDER_RESOLUTION);
-  ui_->jtpHorizontalSlider->setMaximum(current_trajectory.second.back().time / SLIDER_RESOLUTION);
+  ui_->jtpHorizontalSlider->setMinimum(current_trajectory.joint_trajectory.front().time / SLIDER_RESOLUTION);
+  ui_->jtpHorizontalSlider->setMaximum(current_trajectory.joint_trajectory.back().time / SLIDER_RESOLUTION);
   ui_->jtpHorizontalSlider->setSliderPosition(0);
 
   plot_data_map_.clear();
 
-  const std::vector<std::string> joint_names = current_trajectory.second[0].joint_names;
+  const std::vector<std::string> joint_names = current_trajectory.joint_trajectory[0].joint_names;
 
   for (std::size_t i = 0; i < joint_names.size(); ++i)
   {
@@ -48,7 +48,7 @@ JointTrajectoryPlotDialog::JointTrajectoryPlotDialog(tesseract_common::JointTraj
     tesseract_gui::PlotData& velocity = plot_data_map_.getOrCreateNumeric(joint_names[i] + "::velocity");
     tesseract_gui::PlotData& acceleration = plot_data_map_.getOrCreateNumeric(joint_names[i] + "::acceleration");
     double ct{ 0 };
-    for (const auto& state : current_trajectory.second)
+    for (const auto& state : current_trajectory.joint_trajectory)
     {
       position.pushBack(tesseract_gui::PlotDataXY::Point(state.time, state.position(i)));
       velocity.pushBack(tesseract_gui::PlotDataXY::Point(state.time, state.velocity(i)));

--- a/joint_trajectory/src/widgets/joint_trajectory_widget.cpp
+++ b/joint_trajectory/src/widgets/joint_trajectory_widget.cpp
@@ -239,7 +239,7 @@ void JointTrajectoryWidget::onRemove()
 
 void JointTrajectoryWidget::onPlot()
 {
-  if (data_->current_trajectory.second.empty())
+  if (data_->current_trajectory.joint_trajectory.empty())
     return;
 
   data_->plot_dialog = nullptr;
@@ -291,9 +291,9 @@ void JointTrajectoryWidget::onCurrentRowChanged(const QModelIndex& current, cons
         }
       }
 
-      data_->player->setTrajectory(data_->current_trajectory.second);
+      data_->player->setTrajectory(data_->current_trajectory.joint_trajectory);
 
-      if (!data_->current_trajectory.second.empty())
+      if (!data_->current_trajectory.joint_trajectory.empty())
         onEnablePlayer();
 
       break;
@@ -323,14 +323,14 @@ void JointTrajectoryWidget::onCurrentRowChanged(const QModelIndex& current, cons
       }
 
       data_->current_trajectory = tesseract_common::JointTrajectoryInfo();
-      data_->current_trajectory.first = jts.getInitialState();
+      data_->current_trajectory.joint_state = jts.getInitialState();
       for (const auto& t : jts.getJointTrajectories())
-        data_->current_trajectory.second.insert(
-            data_->current_trajectory.second.end(), t.second.begin(), t.second.end());
+        data_->current_trajectory.joint_trajectory.insert(
+            data_->current_trajectory.joint_trajectory.end(), t.joint_trajectory.begin(), t.joint_trajectory.end());
 
-      data_->player->setTrajectory(data_->current_trajectory.second);
+      data_->player->setTrajectory(data_->current_trajectory.joint_trajectory);
 
-      if (!data_->current_trajectory.second.empty())
+      if (!data_->current_trajectory.joint_trajectory.empty())
         onEnablePlayer();
 
       break;


### PR DESCRIPTION
This allows for better debugging and clarity when using the trajectory panel. 

Here is an example of me fully leveraging all the task data getting passed around and using it to help debug.
![image](https://github.com/tesseract-robotics/tesseract_qt/assets/41449746/c8b4ef6e-28e5-4563-be53-c2cdab907809)
