### PR TITLE
Trajectory player fixes

### DIFF
--- a/joint_trajectory/src/widgets/joint_trajectory_widget.cpp
+++ b/joint_trajectory/src/widgets/joint_trajectory_widget.cpp
@@ -412,7 +412,7 @@ void JointTrajectoryWidget::onEnablePlayer()
   ui_->trajectoryPlayerFrame->setEnabled(true);
   ui_->trajectoryPlayButton->setEnabled(true);
   ui_->trajectoryPauseButton->setEnabled(false);
-  ui_->trajectorySlider->setMinimum(data_->player->trajectoryDurationStart() / SLIDER_RESOLUTION);
+  ui_->trajectorySlider->setMinimum(data_->player->trajectoryDurationBegin() / SLIDER_RESOLUTION);
   ui_->trajectorySlider->setMaximum(data_->player->trajectoryDurationEnd() / SLIDER_RESOLUTION);
   ui_->trajectorySlider->setSliderPosition(data_->current_duration);
   ui_->trajectoryCurrentDurationLabel->setText(QString().sprintf("%0.3f", data_->current_duration));

--- a/joint_trajectory/src/widgets/joint_trajectory_widget.cpp
+++ b/joint_trajectory/src/widgets/joint_trajectory_widget.cpp
@@ -408,15 +408,15 @@ void JointTrajectoryWidget::onSliderValueChanged(int value)
 
 void JointTrajectoryWidget::onEnablePlayer()
 {
+  data_->current_duration = data_->player->currentDuration();
   ui_->trajectoryPlayerFrame->setEnabled(true);
   ui_->trajectoryPlayButton->setEnabled(true);
   ui_->trajectoryPauseButton->setEnabled(false);
-  ui_->trajectorySlider->setMinimum(0);
-  ui_->trajectorySlider->setMaximum(data_->player->trajectoryDuration() / SLIDER_RESOLUTION);
-  ui_->trajectorySlider->setSliderPosition(0);
-  ui_->trajectoryCurrentDurationLabel->setText(QString().sprintf("%0.3f", data_->player->currentDuration()));
-  ui_->trajectoryDurationLabel->setText(QString().sprintf("%0.3f", data_->player->trajectoryDuration()));
-  data_->current_duration = 0;
+  ui_->trajectorySlider->setMinimum(data_->player->trajectoryDurationStart() / SLIDER_RESOLUTION);
+  ui_->trajectorySlider->setMaximum(data_->player->trajectoryDurationEnd() / SLIDER_RESOLUTION);
+  ui_->trajectorySlider->setSliderPosition(data_->current_duration);
+  ui_->trajectoryCurrentDurationLabel->setText(QString().sprintf("%0.3f", data_->current_duration));
+  ui_->trajectoryDurationLabel->setText(QString().sprintf("%0.3f", data_->player->trajectoryDurationEnd()));
 }
 
 void JointTrajectoryWidget::onDisablePlayer() { ui_->trajectoryPlayerFrame->setEnabled(false); }


### PR DESCRIPTION
Fix trajectory player for trajectories that do not start from time=0, e.g. when in a trajectory set.

This depends on https://github.com/tesseract-robotics/tesseract/pull/989