### PR TITLE
Fix/crash on row change

### DIFF
--- a/joint_trajectory/src/models/joint_trajectory_model.cpp
+++ b/joint_trajectory/src/models/joint_trajectory_model.cpp
@@ -125,8 +125,14 @@ bool JointTrajectoryModel::hasJointTrajectorySet(const boost::uuids::uuid& uuid)
 
 JointTrajectoryStateItem* findJointStateItem(QStandardItem* item)
 {
+  if (!item)
+    throw std::runtime_error("findJointStateItem: Invalid item selected");
+
   if (item->type() == static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET_STATE))
     return dynamic_cast<JointTrajectoryStateItem*>(item);
+
+  if (!item->parent())
+    throw std::runtime_error("findJointStateItem: Item without a parent selected");
 
   return findJointStateItem(item->parent());
 }
@@ -134,6 +140,9 @@ JointTrajectoryStateItem* findJointStateItem(QStandardItem* item)
 tesseract_common::JointState JointTrajectoryModel::getJointState(const QModelIndex& row) const
 {
   QStandardItem* item = itemFromIndex(row);
+
+  if (!item)
+    throw std::runtime_error("getJointState: invalid item, cannot get joint state");
 
   if (item->type() == static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET_TRAJECTORY))
     throw std::runtime_error("Cannot get joint state from selected joint trajectory standard item");

--- a/joint_trajectory/src/widgets/joint_trajectory_widget.cpp
+++ b/joint_trajectory/src/widgets/joint_trajectory_widget.cpp
@@ -255,8 +255,7 @@ void JointTrajectoryWidget::onCurrentRowChanged(const QModelIndex& current, cons
   onDisablePlayer();
   switch (data_->selected_item->type())
   {
-    case static_cast<int>(StandardItemType::COMMON_NAMESPACE):
-    {
+    case static_cast<int>(StandardItemType::COMMON_NAMESPACE): {
       events::JointTrajectoryToolbarState event(data_->model->getComponentInfo());
       event.save_enabled = false;
       event.remove_enabled = false;
@@ -265,8 +264,7 @@ void JointTrajectoryWidget::onCurrentRowChanged(const QModelIndex& current, cons
 
       break;
     }
-    case static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET_TRAJECTORY):
-    {
+    case static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET_TRAJECTORY): {
       events::JointTrajectoryToolbarState event(data_->model->getComponentInfo());
       event.save_enabled = false;
       event.remove_enabled = false;
@@ -298,8 +296,7 @@ void JointTrajectoryWidget::onCurrentRowChanged(const QModelIndex& current, cons
 
       break;
     }
-    case static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET):
-    {
+    case static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET): {
       events::JointTrajectoryToolbarState event(data_->model->getComponentInfo());
       event.save_enabled = true;
       event.remove_enabled = true;

--- a/joint_trajectory/src/widgets/joint_trajectory_widget.cpp
+++ b/joint_trajectory/src/widgets/joint_trajectory_widget.cpp
@@ -255,7 +255,8 @@ void JointTrajectoryWidget::onCurrentRowChanged(const QModelIndex& current, cons
   onDisablePlayer();
   switch (data_->selected_item->type())
   {
-    case static_cast<int>(StandardItemType::COMMON_NAMESPACE): {
+    case static_cast<int>(StandardItemType::COMMON_NAMESPACE):
+    {
       events::JointTrajectoryToolbarState event(data_->model->getComponentInfo());
       event.save_enabled = false;
       event.remove_enabled = false;
@@ -264,7 +265,8 @@ void JointTrajectoryWidget::onCurrentRowChanged(const QModelIndex& current, cons
 
       break;
     }
-    case static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET_TRAJECTORY): {
+    case static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET_TRAJECTORY):
+    {
       events::JointTrajectoryToolbarState event(data_->model->getComponentInfo());
       event.save_enabled = false;
       event.remove_enabled = false;
@@ -296,7 +298,8 @@ void JointTrajectoryWidget::onCurrentRowChanged(const QModelIndex& current, cons
 
       break;
     }
-    case static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET): {
+    case static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET):
+    {
       events::JointTrajectoryToolbarState event(data_->model->getComponentInfo());
       event.save_enabled = true;
       event.remove_enabled = true;
@@ -332,7 +335,8 @@ void JointTrajectoryWidget::onCurrentRowChanged(const QModelIndex& current, cons
 
       break;
     }
-    default: {
+    default:
+    {
       try
       {
         events::JointTrajectoryToolbarState event(data_->model->getComponentInfo());

--- a/joint_trajectory/src/widgets/joint_trajectory_widget.cpp
+++ b/joint_trajectory/src/widgets/joint_trajectory_widget.cpp
@@ -335,28 +335,36 @@ void JointTrajectoryWidget::onCurrentRowChanged(const QModelIndex& current, cons
 
       break;
     }
-    default:
-    {
-      events::JointTrajectoryToolbarState event(data_->model->getComponentInfo());
-      event.save_enabled = false;
-      event.remove_enabled = false;
-      event.plot_enabled = false;
-      QApplication::sendEvent(qApp, &event);
-
-      const tesseract_common::JointState& state = data_->model->getJointState(current_index);
-      auto jts = data_->model->getJointTrajectorySet(current_index);
-
-      if (jts.getEnvironment() != nullptr && jts.getEnvironment()->isInitialized())
+    default: {
+      try
       {
-        if (data_->model->getComponentInfo()->hasParent() && data_->current_environment != jts.getEnvironment())
-        {
-          auto env_wrapper =
-              std::make_shared<DefaultEnvironmentWrapper>(data_->model->getComponentInfo(), jts.getEnvironment());
-          EnvironmentManager::set(env_wrapper);
-        }
+        events::JointTrajectoryToolbarState event(data_->model->getComponentInfo());
+        event.save_enabled = false;
+        event.remove_enabled = false;
+        event.plot_enabled = false;
+        QApplication::sendEvent(qApp, &event);
 
-        data_->current_environment = jts.getEnvironment();
-        data_->current_environment->setState(state.joint_names, state.position);
+        const tesseract_common::JointState& state = data_->model->getJointState(current_index);
+        auto jts = data_->model->getJointTrajectorySet(current_index);
+
+        if (jts.getEnvironment() != nullptr && jts.getEnvironment()->isInitialized())
+        {
+          if (data_->model->getComponentInfo()->hasParent() && data_->current_environment != jts.getEnvironment())
+          {
+            auto env_wrapper =
+                std::make_shared<DefaultEnvironmentWrapper>(data_->model->getComponentInfo(), jts.getEnvironment());
+            EnvironmentManager::set(env_wrapper);
+          }
+
+          data_->current_environment = jts.getEnvironment();
+          data_->current_environment->setState(state.joint_names, state.position);
+        }
+      }
+      catch (const std::runtime_error& ex)
+      {
+        std::stringstream sstr;
+        sstr << "Error in onCurrentRowChanged default, not updating env state: " << ex.what() << std::endl;
+        CONSOLE_BRIDGE_logDebug(sstr.str().c_str());
       }
 
       break;


### PR DESCRIPTION
Prevents crashing if you click in the values column to the right of a trajectory set item without a parent.  