### PR TITLE
Fix clang format for newer versions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -54,6 +54,7 @@ BreakBeforeBraces: Custom
 
 # Control of individual brace wrapping cases
 BraceWrapping: 
+    AfterCaseLabel : 'true'
     AfterClass: 'true'
     AfterControlStatement: 'true'
     AfterEnum : 'true'
@@ -64,6 +65,5 @@ BraceWrapping:
     BeforeCatch : 'true'
     BeforeElse : 'true'
     IndentBraces : 'false'
-    AfterCaseLabel : 'true'
 
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -53,7 +53,7 @@ UseTab: Never
 BreakBeforeBraces: Custom
 
 # Control of individual brace wrapping cases
-BraceWrapping: {
+BraceWrapping: 
     AfterClass: 'true'
     AfterControlStatement: 'true'
     AfterEnum : 'true'
@@ -64,5 +64,6 @@ BraceWrapping: {
     BeforeCatch : 'true'
     BeforeElse : 'true'
     IndentBraces : 'false'
-}
+    AfterCaseLabel : 'true'
+
 ...

--- a/.run-clang-format
+++ b/.run-clang-format
@@ -1,2 +1,2 @@
 #!/bin/bash
-find . -type f -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\|hxx\)' -exec clang-format -style=file -i {} \;
+find . -type f -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\|hxx\)' -exec clang-format-14 -style=file -i {} \;

--- a/.run-clang-format
+++ b/.run-clang-format
@@ -1,2 +1,2 @@
 #!/bin/bash
-find . -type f -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\|hxx\)' -exec clang-format-8 -style=file -i {} \;
+find . -type f -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\|hxx\)' -exec clang-format -style=file -i {} \;


### PR DESCRIPTION
This works for me with clang-format-14 on 22.04

After https://github.com/tesseract-robotics/tesseract_qt/pull/101