### PR TITLE
Fix trajectory removal

### DIFF
--- a/common/include/tesseract_qt/common/events/joint_trajectory_events.h
+++ b/common/include/tesseract_qt/common/events/joint_trajectory_events.h
@@ -87,7 +87,7 @@ public:
   const std::string& getNamespace() const;
 
   /** @brief Unique type for this event. */
-  static const QEvent::Type kType = QEvent::Type(EventType::JOINT_TRAJECTORY_REMOVE_ALL);
+  static const QEvent::Type kType = QEvent::Type(EventType::JOINT_TRAJECTORY_REMOVE_NAMESPACE);
 
 private:
   std::string ns_;


### PR DESCRIPTION
Wrong event name caused a crash, because remove all executed remove namespace without a namespace.