### PR TITLE
Require loading task composer config before log file

### DIFF
--- a/planning/src/widgets/task_composer_tool_bar.cpp
+++ b/planning/src/widgets/task_composer_tool_bar.cpp
@@ -86,6 +86,7 @@ TaskComposerToolBar::TaskComposerToolBar(std::shared_ptr<const ComponentInfo> co
       data_->default_config_dir = QFileInfo(config_filepath).absoluteDir().path();
       events::TaskComposerLoadConfig event(data_->component_info, config_filepath.toStdString());
       QApplication::sendEvent(qApp, &event);
+      data_->load_log_action->setEnabled(true);
     }
   });
 
@@ -115,6 +116,7 @@ TaskComposerToolBar::TaskComposerToolBar(std::shared_ptr<const ComponentInfo> co
       QApplication::sendEvent(qApp, &event);
     }
   });
+  data_->load_log_action->setEnabled(false);
 
   addSeparator();
 


### PR DESCRIPTION
In order to load a log all libraries must be loaded and the serialized classes be registered. In order for this to happen you must load the task composer config used to generated the log. This updates the toolbar so you are required to load your config prior to trying to load a log file. @marip8 