### PR TITLE
Updated QStandardItem status log icon based on severity

### DIFF
--- a/common/src/models/status_log_model.cpp
+++ b/common/src/models/status_log_model.cpp
@@ -49,7 +49,18 @@ QList<QStandardItem*> getItems(const QString& severity, const QString& message, 
 {
   QList<QStandardItem*> items;
   items.append(new QStandardItem(QDateTime::currentDateTime().toString("dd MMMM yyyy hh:mm:ss.zzz")));
-  items.append(new QStandardItem(icons::getInfoMsgIcon(), severity));
+  if (severity == "Info")
+  {
+    items.append(new QStandardItem(icons::getInfoMsgIcon(), severity));
+  }
+  else if (severity == "Warn")
+  {
+    items.append(new QStandardItem(icons::getWarnMsgIcon(), severity));
+  }
+  else if (severity == "Error")
+  {
+    items.append(new QStandardItem(icons::getErrorMsgIcon(), severity));
+  }
   items.append(new QStandardItem(message));
   items.back()->setForeground(color);
   return items;


### PR DESCRIPTION
This PR varies the QStandardItem icon based on the severity of the event instead of defaulting to an "Info" icon. 