### PR TITLE
Fixed naming of GZ_RENDERING variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,9 +104,9 @@ if(${BUILD_RENDERING})
   message("Building rendering module")
   add_subdirectory(rendering)
   if((EXISTS LSB_RELEASE_CODE_SHORT) AND (LSB_RELEASE_CODE_SHORT STREQUAL "noble"))
-    set(GZ-RENDERING gz-rendering8)
+    set(GZ_RENDERING gz-rendering8)
   else()
-    set(GZ-RENDERING gz-rendering7)
+    set(GZ_RENDERING gz-rendering7)
   endif()
   list(
     APPEND


### PR DESCRIPTION
The `GZ_RENDERING` variable used to specify the dependency for the package build was actually set as `GZ-RENDERING`, causing the dependency to be specified as `lib-dev` rather than `lib-gz-rendering8-dev` which makes the package uninstallable.

This PR updates the name to fix the package