### PR TITLE
Fix off-by-one in SceneGraphStandardItem::clear + dedupe addLink

### DIFF
--- a/scene_graph/src/models/scene_graph_standard_item.cpp
+++ b/scene_graph/src/models/scene_graph_standard_item.cpp
@@ -82,6 +82,9 @@ void SceneGraphStandardItem::setName(const std::string& name)
 
 void SceneGraphStandardItem::addLink(const tesseract::scene_graph::Link& link)
 {
+  if (data_->links.find(link.getName()) != data_->links.end())
+    removeLink(link.getName());
+
   auto* item = new LinkStandardItem(
       QString::fromStdString(link.getName()), std::make_shared<tesseract::scene_graph::Link>(link.clone()), true);
 
@@ -162,10 +165,10 @@ void SceneGraphStandardItem::clear()
 {
   data_->name_item[1]->setData("Empty", Qt::DisplayRole);
 
-  for (int i = data_->links_item->rowCount(); i > 0; --i)
+  for (int i = data_->links_item->rowCount() - 1; i >= 0; --i)
     data_->links_item->removeRow(i);
 
-  for (int i = data_->joints_item->rowCount(); i > 0; --i)
+  for (int i = data_->joints_item->rowCount() - 1; i >= 0; --i)
     data_->joints_item->removeRow(i);
 
   data_->links.clear();


### PR DESCRIPTION
Two small fixes in scene_graph/src/models/scene_graph_standard_item.cpp.

**clear() off-by-one.** 

The loop iterates from rowCount() down to 1 and calls removeRow(i), but removeRow uses 0-based indices. The first iteration's removeRow(rowCount()) is out of bounds and a no-op; subsequent iterations remove rows N-1, N-2, ..., 1, never touching row 0. data_->links.clear() then drops the map entry, so the orphan row is no longer tracked anywhere. The joints loop has the same bug. Fix by iterating rowCount()-1 down to 0.

This is observable in any consumer that broadcasts SceneGraphSet on state change — for example the JointTrajectory Workbench, which broadcasts on every trajectory selection: setSceneGraph -> clear() (leaves one stale row) -> addLink for each new link, so the Scene tab tree accumulates one orphan row per selection until it plateaus at base + 1.

**addLink dedup.**

addLink unconditionally appends a new row. If a SceneGraphAddLink event ever fires for a link name that already exists in the model (e.g. an env command applied with replace_allowed=true emitted incrementally rather than via SceneGraphSet), the previous QStandardItem is orphaned because data_->links overwrites the map entry but the row stays in links_item. Guard with removeLink when the name is already present, mirroring the setSceneGraph -> clear() pattern.