### PR TITLE
Fix package.xml: replace cmake target deps with tesseract_planning package

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,9 +22,7 @@
   <depend>tesseract_support</depend>
   <depend>tesseract_urdf</depend>
   <depend>tesseract_visualization</depend>
-  <depend>tesseract_command_language</depend>
-  <depend>tesseract_motion_planners</depend>
-  <depend>tesseract_task_composer</depend>
+  <depend>tesseract_planning</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>


### PR DESCRIPTION
## Problem

`package.xml` declares dependencies on `tesseract_command_language`, `tesseract_motion_planners`, and `tesseract_task_composer` as if they were separate ROS packages. These were once individual packages but have since been consolidated into the `tesseract_planning` monorepo as cmake libraries under a single ROS package.

As a result, colcon cannot resolve these as workspace dependencies and starts building `tesseract_qt` before `tesseract_planning` is ready, causing the build to fail with:

```
Could not find a package configuration file provided by "tesseract_command_language"
```

## Fix

Replace the three stale entries with a single `<depend>tesseract_planning</depend>`, which is the actual ROS package name that colcon can resolve correctly.

## Test

Verified that `tesseract_qt` now builds successfully from source in a full workspace build.