### PR TITLE
Fix visibility rendering

### DIFF
--- a/common/src/environment_wrapper.cpp
+++ b/common/src/environment_wrapper.cpp
@@ -171,7 +171,9 @@ void tesseractEventFilterHelper(const tesseract::environment::Event& event,
           }
         }
         if (broadcast)
+        {
           env_wrapper.broadcast();
+        }
       }
       current_revision = e.revision;
       break;

--- a/rendering/src/gazebo_utils.cpp
+++ b/rendering/src/gazebo_utils.cpp
@@ -301,7 +301,7 @@ std::shared_ptr<gz::rendering::Visual> loadLink(gz::rendering::Scene& scene,
 {
   auto entity = entity_container.addTrackedEntity(tesseract::gui::EntityContainer::VISUAL_NS, link.getName());
   std::shared_ptr<gz::rendering::Visual> ign_link = scene.CreateVisual(entity.id, entity.unique_name);
-  ign_link->SetUserData(USER_VISIBILITY, true);
+  ign_link->SetUserData(USER_VISIBILITY, link.visible);
 
   std::shared_ptr<gz::rendering::Visual> ign_link_visuals = loadLinkVisuals(scene, entity_container, link);
   ign_link_visuals->SetUserData(USER_VISIBILITY, true);
@@ -323,7 +323,9 @@ std::shared_ptr<gz::rendering::Visual> loadLink(gz::rendering::Scene& scene,
     ign_link->AddChild(ign_link_wirebox);
   }
 
-  // Cannot set visibilty to false in loadLinkCollisions because LocalBoundingBox only calculates for visible objects
+  // Cannot set visibilty to false in loadLinkVisuals/loadLinkCollisions before LocalBoundingBox is computed above,
+  // because it only calculates for visible objects
+  ign_link_visuals->SetVisible(link.visible);
   ign_link_collisions->SetVisible(false);
 
   return ign_link;

--- a/scene_graph/src/models/link_standard_item.cpp
+++ b/scene_graph/src/models/link_standard_item.cpp
@@ -74,7 +74,7 @@ void LinkStandardItem::ctor(bool checkable)
   if (checkable)
   {
     setCheckable(true);
-    setCheckState(Qt::CheckState::Checked);
+    setCheckState(link->visible ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
   }
 
   appendRow(createStandardItemString("name", link->getName()));

--- a/scene_graph/src/models/scene_graph_standard_item.cpp
+++ b/scene_graph/src/models/scene_graph_standard_item.cpp
@@ -85,14 +85,10 @@ void SceneGraphStandardItem::addLink(const tesseract::scene_graph::Link& link)
   if (data_->links.find(link.getName()) != data_->links.end())
     removeLink(link.getName());
 
-  auto* item = new LinkStandardItem(
-      QString::fromStdString(link.getName()), std::make_shared<tesseract::scene_graph::Link>(link.clone()), true);
+  auto* item = new LinkStandardItem(QString::fromStdString(link.getName()),
+                                    std::make_shared<tesseract::scene_graph::Link>(link.clone()),
+                                    data_->checkable);
 
-  if (data_->checkable)
-  {
-    item->setCheckable(true);
-    item->setCheckState(Qt::CheckState::Checked);
-  }
   data_->links_item->appendRow(item);
   data_->links_item->sortChildren(0);
   data_->links[link.getName()] = item;


### PR DESCRIPTION
Fix visibility rendering to let `CHANGE_LINK_VISIBILITY ` work.

See also https://github.com/tesseract-robotics/tesseract_ros2/pull/192