### PR TITLE
Guard size()-1 loop bound against an empty link list

### DIFF
--- a/common/src/environment_wrapper.cpp
+++ b/common/src/environment_wrapper.cpp
@@ -288,7 +288,7 @@ void eventFilterHelper(QObject* /*obj*/,
     }
 
     std::vector<std::string> link_names = env.getLinkNames();
-    for (std::size_t i = 0; i < link_names.size() - 1; ++i)
+    for (std::size_t i = 0; i + 1 < link_names.size(); ++i)
     {
       const auto& link1 = env.getLink(link_names[i]);
       if (link1->collision.empty())


### PR DESCRIPTION
`link_names.size() - 1` wraps to `SIZE_MAX` when the environment has no links, so the loop body runs once and indexes an empty vector. The indexing is the first statement of the body, ahead of the inner loop's own bound, so nothing downstream catches it.

`i + 1 < size()` is equivalent for every non-empty input.

Same fix as tesseract-robotics/tesseract#1334, which covers two instances of this in `tesseract`.