### PR TITLE
Move ccache setup into colcon-action@v15

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -9,6 +9,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   clang_format:
     runs-on: ubuntu-24.04

--- a/.github/workflows/cmake_format.yml
+++ b/.github/workflows/cmake_format.yml
@@ -9,6 +9,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   cmake_lang:
     name: Format

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: ${{ matrix.distro }}

--- a/.github/workflows/package_debian.yml
+++ b/.github/workflows/package_debian.yml
@@ -8,6 +8,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   get-tag:
     # Pre-job to fetch the latest tag

--- a/.github/workflows/package_debian.yml
+++ b/.github/workflows/package_debian.yml
@@ -78,7 +78,7 @@ jobs:
           apt install -y libqt-advanced-docking-system-dev
 
       - name: Build and test
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
           before-script: source /opt/tesseract/install/setup.bash && source /opt/tesseract_planning/install/setup.bash
           ccache-enabled: false

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -48,7 +48,6 @@ jobs:
     container:
       image: ghcr.io/tesseract-robotics/tesseract_planning:${{ matrix.distro }}-${{ needs.get-tag.outputs.major }}.${{ needs.get-tag.outputs.minor }}
       env:
-        CCACHE_DIR: "$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache"
         DEBIAN_FRONTEND: noninteractive
         TZ: Etc/UTC
     steps:
@@ -79,9 +78,9 @@ jobs:
           apt install -y libqt-advanced-docking-system-dev
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
           before-script: source /opt/tesseract/install/setup.bash && source /opt/tesseract_planning/install/setup.bash
-          ccache-prefix: ${{ matrix.distro }}
+          ccache-prefix: ubuntu-${{ matrix.distro }}
           target-path: target_ws/src
           target-args: --cmake-args -DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,6 +10,11 @@ on:
   release:
     types:
       - released
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   get-tag:
     # Pre-job to fetch the latest tag

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -21,7 +21,6 @@ jobs:
     container:
       image: ghcr.io/tesseract-robotics/tesseract_planning:${{ matrix.distro }}-master
       env:
-        CCACHE_DIR: "$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache"
         DEBIAN_FRONTEND: noninteractive
         TZ: Etc/UTC
     steps:
@@ -52,9 +51,9 @@ jobs:
           apt install -y libqt-advanced-docking-system-dev
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
           before-script: source /opt/tesseract/install/setup.bash && source /opt/tesseract_planning/install/setup.bash
-          ccache-prefix: ${{ matrix.distro }}
+          ccache-prefix: unstable-${{ matrix.distro }}
           target-path: target_ws/src
           target-args: --cmake-args -DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_TESTING=ON -DTESSERACT_PACKAGE=ON

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -10,6 +10,11 @@ on:
   release:
     types:
       - released
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: ${{ matrix.distro }}


### PR DESCRIPTION
Fourth in the series that moves ccache wiring out of the workflows and into
[colcon-action](https://github.com/tesseract-robotics/colcon-action); tesseract#1351,
tesseract_planning#769 and trajopt#580 were the first three. Fixes tesseract#1345 and
tesseract#1346 for this repo.

### What was wrong

**`CCACHE_DIR` pointed where nothing was cached.** `ubuntu.yml` and `unstable.yml` set it in the
container `env:` map as a literal `$GITHUB_WORKSPACE/...`. GitHub never runs a shell over that map,
so the variable stayed unexpanded. On noble ccache expands `$VAR` in its own config (4.9+) and it
happened to work; on jammy (4.5.1) it did not, and the directory handed to `actions/cache` was not
the directory ccache filled. `@v15` resolves the path by asking ccache, so the line is deleted
rather than corrected.

**`ubuntu` and `unstable` shared one restore namespace.** `@v15`'s restore key is
`<prefix>-<runner.os>-ccache-<github.job>-`, and the job id is `ci` in both, so an identical
`${{ matrix.distro }}` prefix put two different build configurations — a release-image build and a
`-master`-image build — in one `ccache-maxsize` cap. They are now `ubuntu-` and `unstable-` prefixed.

`package_debian.yml` is bumped in its own commit. `ccache-enabled: false` opts out of ccache, not out
of the action, and v14→v15 also carries `$SUDO` handling and `action_repository` changes.

Nothing else to strip here: no workflow in this repo passes `-DCMAKE_CXX_COMPILER_LAUNCHER=ccache` in
its CMake arguments, none has a hand-rolled `Configure ccache` or `Report ccache statistics` step,
and unlike the previous two repos no `ccache-prefix` names a matrix key its matrix does not define —
`matrix.distro` is defined in both files.

### Every workflow is cold exactly once

`@v14`'s restore key used lowercase `linux`; `@v15` uses `${{ runner.os }}`, which is `Linux`. No
`@v14` entry can prefix-match a `@v15` restore key, so every workflow here is cold on its first run
after this merges regardless of the prefix renames. One cold run, then normal.

### Pre-existing failures, none of them caused by this PR

Censused on `master` at 4cb8819 before the first edit. `Clang-Format`, `CMake-Format`, `Docker` and
`Unstable` are all green there; one workflow is not:

- **`Ubuntu` is red on `master` itself.** It pins the released image tag
  `tesseract_planning:<distro>-<major>.<minor>`, currently `0.35`, whose tesseract_planning predates
  the current `JointValues` API, so `tesseract_qt` fails to **compile** `joint_trajectory_set.h`
  (`'JointValues' in 'struct ...'`) after 27.5 s (jammy) / 15.7 s (noble), `0 packages finished`.
  It will stay red until a new tesseract_planning release is tagged. `Package-Debian-Build` pins a
  release tag too and fails the same way.

This repo has no `mac.yml`, no `windows.yml` and no `code_quality.yml`, so with `Ubuntu` red the
`Unstable` workflow is the only one here that can produce a warm hit rate. Its image tracks
`-master` and changes daily, which structurally lowers that rate; the restore, save, prefix and
environment signals it produces are unambiguous either way.

### Measured

Two consecutive runs, cold then warm, on this branch — the warm one obtained by re-running the first
rather than by pushing a throwaway commit, so the branch stays at exactly what will merge. The figure
is the **`Build and Tests` step**, not the run.

| leg | cold | warm | warm hits |
| --- | --- | --- | --- |
| unstable jammy / noble | 7.3 / 6.7 m | **2.4 / 1.4 m** | 341/344 (99.1%) · 335/343 (97.7%) |
| ubuntu jammy / noble | 1.7 / 0.9 m | 1.5 / 0.6 m | 27/31 · 18/28 |

`Cache size (GB)` peaked at 0.17 / 1.00, so the `1G` cap has ample headroom here.

Two caveats on those numbers, both worth stating so they are not read as more than they are:

- **`Unstable`'s hit rate is flattering.** It pulls `tesseract_planning:<distro>-master`, which
  changes daily; the warm run here was a re-run minutes after the cold one, so it pulled the
  identical image. Across days that rate will be lower, and a genuine miss from a changed header
  looks exactly like a failed restore in a percentage. The signal that does not degrade is
  `Cache restored from key:`, which is present on every job of every run here.
- **`Ubuntu` fails at compile, so its sample is 31–72 calls, not zero.** Its restore, save, prefix
  and environment signals are all readable and all correct; its hit rate and build time are not
  meaningful on that sample.

A note for anyone reproducing the `Cacheable calls` check: ccache 4.5.1 on jammy does not print that
line at all. Its `ccache -s` prints `Summary:` then `Hits: x / N`; read that denominator instead.
Only noble (4.9) has a `Cacheable calls:` line.

### Verification

Worked in two phases, because the two changes in this PR are verified by opposite actions — ccache
needs two runs that both complete, cancellation needs a push that interrupts one.

**Phase A — ccache.** On all four jobs of both workflows: `CCACHE_DIR` resolved by the action to
`/__w/tesseract_qt/tesseract_qt/.ccache`, `CCACHE_MAXSIZE: 1G`, `Statistics zeroed` after the
restore, both `CMAKE_C_` and `CMAKE_CXX_COMPILER_LAUNCHER` exported, a real `Cache saved with key:`,
then on the second run `Cache restored from key:` naming the first run's key. **Zero `::warning::`
from the action and zero `Path Validation Error` in any post-job cleanup, across every job of every
run on this branch.**

The renamed prefixes are visible in the keys and no longer collide:
`ubuntu-{jammy,noble}-Linux-ccache-ci-…` against `unstable-{jammy,noble}-Linux-ccache-ci-…`.

The restore chain was followed across three generations and a **different commit**: the phase-B head
restored `unstable-noble-Linux-ccache-ci-32563886037-2` — the previous run's entry — and saved a
fresh one. The restore key carries neither the sha nor the run id, so a cache populated on one
revision is available to the next.

**Phase B — concurrency.** All 6 workflows take the block; all 6 are schema-valid, so nothing is
excluded. Pushed, waited for the matrix to go live, pushed an empty commit, then force-pushed to
drop it — two independent observations. Both times **3 of 3 in-flight runs cancelled** (`Ubuntu`,
`Unstable`, `Docker`), with both format checks, which had already finished, staying `success`.
Cancellation supersedes only what is still live, which is the behaviour that makes this safe on push
and release.

**`Package-Debian-Build`** was verified by `workflow_dispatch` on a fork, since no pull request can
trigger a tag-push workflow. On both legs the action's `Configure ccache`, `Restore cache`,
`Zero ccache statistics`, `Report ccache statistics` and `Save cache` steps all report
`outcome=skipped` under `ccache-enabled: false`, with no warnings. The run then fails at the same
pre-existing `JointValues` error as `Ubuntu`.
